### PR TITLE
return token promise by recaptcha.execute

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -82,14 +82,22 @@ var GoogleRecaptcha = function (_React$Component) {
             badge: badge,
             callback: _this2.callbackName
           });
-          _this2.execute = function () {
-            return window.grecaptcha.execute(recaptchaId);
-          };
           _this2.reset = function () {
             return window.grecaptcha.reset(recaptchaId);
           };
           _this2.getResponse = function () {
             return window.grecaptcha.getResponse(recaptchaId);
+          };
+          _this2.execute = function () {
+            return new Promise(function (resolve) {
+              // patch callback to return promise
+              var callback = window[_this2.callbackName];
+              window[_this2.callbackName] = function () {
+                resolve(_this2.getResponse());
+                callback.apply(undefined, arguments);
+              };
+              window.grecaptcha.execute(recaptchaId);
+            });
           };
         }
       };

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,17 @@ class GoogleRecaptcha extends React.Component {
           badge,
           callback: this.callbackName
         });
-        this.execute = () => window.grecaptcha.execute( recaptchaId );
         this.reset = () => window.grecaptcha.reset( recaptchaId );
         this.getResponse = () => window.grecaptcha.getResponse( recaptchaId );
+        this.execute = () => new Promise(resolve => {
+          // patch callback to return promise
+          const callback = window[ this.callbackName ];
+          window[ this.callbackName ] = (...args) => {
+            resolve(this.getResponse());
+            callback(...args);
+          };
+          window.grecaptcha.execute(recaptchaId);
+        });
       }
     };
 


### PR DESCRIPTION
after this changes you can use recaptcha.execute this way:
```JavaScript
this.recaptcha.execute()
  .then(recaptchaToken => submitForm(recaptchaToken))
```
so you dont't need `onResolved` and `getResponse` methods