### PR TITLE
Add callback when recaptcha is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A few optional props you can tweak.
 * locale: in which language it speaks. **Default: en.**
 * badge: `bottomright`, `bottomleft`, or `inline`. **Default: bottomright.**
 * style: custom CSS applied to the root node. **Default: undefined.**
+* onLoad: callback when the recaptcha loads. **Default: noop.**
 
 ## APIs ##
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -66,7 +66,8 @@ var GoogleRecaptcha = function (_React$Component) {
           sitekey = _props.sitekey,
           locale = _props.locale,
           badge = _props.badge,
-          onResolved = _props.onResolved;
+          onResolved = _props.onResolved,
+          onLoad = _props.onLoad;
 
 
       this.callbackName = 'GoogleRecaptchaResolved-' + (0, _v2.default)();
@@ -89,6 +90,7 @@ var GoogleRecaptcha = function (_React$Component) {
           _this2.getResponse = function () {
             return window.grecaptcha.getResponse(recaptchaId);
           };
+          onLoad();
         }
       };
 
@@ -128,12 +130,14 @@ GoogleRecaptcha.propTypes = {
   locale: _propTypes2.default.string,
   badge: _propTypes2.default.oneOf(['bottomright', 'bottomleft', 'inline']),
   onResolved: _propTypes2.default.func.isRequired,
+  onLoad: _propTypes2.default.func,
   style: _propTypes2.default.object
 };
 
 GoogleRecaptcha.defaultProps = {
   locale: 'en',
-  badge: 'bottomright'
+  badge: 'bottomright',
+  onLoad: function onLoad() {}
 };
 
 exports.default = GoogleRecaptcha;

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const injectScript = locale => {
 
 class GoogleRecaptcha extends React.Component {
   componentDidMount() {
-    const { sitekey, locale, badge, onResolved } = this.props;
+    const { sitekey, locale, badge, onResolved, onLoad } = this.props;
 
     this.callbackName = 'GoogleRecaptchaResolved-' + uuid();
     window[ this.callbackName ] = onResolved;
@@ -40,6 +40,7 @@ class GoogleRecaptcha extends React.Component {
         this.execute = () => window.grecaptcha.execute( recaptchaId );
         this.reset = () => window.grecaptcha.reset( recaptchaId );
         this.getResponse = () => window.grecaptcha.getResponse( recaptchaId );
+        onLoad();
       }
     };
 
@@ -69,12 +70,14 @@ GoogleRecaptcha.propTypes = {
   locale: PropTypes.string,
   badge: PropTypes.oneOf( [ 'bottomright', 'bottomleft', 'inline' ] ),
   onResolved: PropTypes.func.isRequired,
+  onLoad: PropTypes.func,
   style: PropTypes.object
 };
 
 GoogleRecaptcha.defaultProps = {
   locale: 'en',
-  badge: 'bottomright'
+  badge: 'bottomright',
+  onLoad: () => {},
 };
 
 export default GoogleRecaptcha;


### PR DESCRIPTION
Calling `execute` when recaptcha is not loaded causes problems.

Since it's loaded asynchronously I added new prop `onLoad`
that will be called after the script loads.