### PR TITLE
Reset widget prior to removing elements from DOM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,13 +77,13 @@ class GoogleRecaptcha extends React.Component {
     }
   }
   componentWillUnmount() {
-    while ( this.container.firstChild ) {
-      this.container.removeChild( this.container.firstChild );
-    }
     // There is a chance that the reCAPTCHA API lib is not loaded yet, so check
     // before invoking reset.
     if ( this.reset ) {
       this.reset();
+    }
+    while ( this.container.firstChild ) {
+      this.container.removeChild( this.container.firstChild );
     }
     delete window[ this.callbackName ];
   }


### PR DESCRIPTION
reCAPTCHA throws an error when trying to `reset` _after_ elements have been removed from the DOM. This error occurs during the `componentWillUnmount` lifecycle method.

<img width="314" alt="Screen Shot 2019-04-18 at 1 50 34 PM" src="https://user-images.githubusercontent.com/2466445/56390566-2e125500-61e1-11e9-9c2d-5d89f148689f.png">
